### PR TITLE
Fix bugs on proceedings page

### DIFF
--- a/src/lib/components/ToolListviewCard.svelte
+++ b/src/lib/components/ToolListviewCard.svelte
@@ -24,7 +24,7 @@
 			>
 				<div class="aspect-square object-cover h-32 p-4">
 					{#if docsUrl}
-						<a href={`https://www.${docsUrl.href}/`} target="_blank" rel="noopener noreferrer">
+						<a href={`https://www.${docsUrl.href}`} target="_blank" rel="noopener noreferrer">
 							<img
 								src={`${base}/tool_icons/${tool.image}`}
 								alt={`The icon of the ${tool.name} neuroimaging tool`}
@@ -46,7 +46,7 @@
 					{#if tool?.urls?.length > 0}
 						<div class="truncate pb-2">
 							<a
-								href={`https://${tool.urls[0].href}/`}
+								href={`${tool.urls[0].href}/`}
 								target="_blank"
 								rel="noopener noreferrer"
 								class="underline text-sky-500 hover:text-sky-700 decoration-sky-500 hover:decoration-sky-700"
@@ -97,7 +97,9 @@
 	.card-wrapper:hover,
 	.card-wrapper:focus {
 		transform: scale(1.05);
-		box-shadow: rgba(0, 0, 0, 0.2) 0px 25px 30px -5px, rgba(0, 0, 0, 0.15) 0px 10px 12px -6px;
+		box-shadow:
+			rgba(0, 0, 0, 0.2) 0px 25px 30px -5px,
+			rgba(0, 0, 0, 0.15) 0px 10px 12px -6px;
 		border-color: rgb(90, 92, 106);
 	}
 </style>

--- a/src/lib/components/ToolListviewCard.svelte
+++ b/src/lib/components/ToolListviewCard.svelte
@@ -97,9 +97,7 @@
 	.card-wrapper:hover,
 	.card-wrapper:focus {
 		transform: scale(1.05);
-		box-shadow:
-			rgba(0, 0, 0, 0.2) 0px 25px 30px -5px,
-			rgba(0, 0, 0, 0.15) 0px 10px 12px -6px;
+		box-shadow: rgba(0, 0, 0, 0.2) 0px 25px 30px -5px, rgba(0, 0, 0, 0.15) 0px 10px 12px -6px;
 		border-color: rgb(90, 92, 106);
 	}
 </style>

--- a/src/lib/data/back_migrate_tools.js
+++ b/src/lib/data/back_migrate_tools.js
@@ -5,7 +5,6 @@ import { join } from 'path';
 const PATH_DIR_ENTRIES_INPUT = 'src/lib/data/entries';
 const PATH_DIR_ENTRIES_OUTPUT = 'src/lib/data/evaluatedTools';
 
-
 const OUTPUT_SKELETON = {
 	"name": null,
 	"description": null,
@@ -23,8 +22,7 @@ const EVALUATION_SKELETON = {
 	"date": null,
 	"evaluatorEmail": "nmind@nmind.mock",
 	"checklist": {}
-}
-
+};
 
 /**
  * Read all json files from the input directory
@@ -83,6 +81,7 @@ function backMigrate(entry) {
 	entry_backmigrated.description = `This tool was migrated from the old format. Please update it.`;
 	entry_backmigrated.urls = entry.urls.map(x => ({ "text": x.url_type, href: x.url }));
 	entry_backmigrated.slug = makeUrlSafeName(entry.name);
+	entry_backmigrated.evaluations = entry.evaluations ? entry.evaluations : [];
 
 	const evaluation = { ...EVALUATION_SKELETON };
 	// set date as today in the format YYYY-MM-DD

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -43,7 +43,7 @@
 			{#each data?.urls as url (url)}
 				<li class="mb-2">
 					<a
-						href={`https://${url.href}/`}
+						href={`${url.href}`}
 						target="_blank"
 						rel="noopener noreferrer"
 						class="underline decoration-transparent transition duration-300 ease-in-out hover:decoration-inherit"


### PR DESCRIPTION
This PR addresses 2 bugs on the proceedings page:

1. All of the redirect URLs prepended an "https://" to the provided tool URL, which already contained "https://" - I've removed the prepend in this PR.

2. The evaluations themselves also (i) populated the same checklist for all tools and (ii) combined the evaluations of other tools as previous evaluation of the tool being evaluated.  Both of these seemed to have been caused by a referencing issue when pushing to `entry_backmigrated.evaluations` in `backMigrate`. I've instantiated the evaluations within the function itself if it doesn't already exist so it should resolve combination of evaluations of different tools. 