### PR TITLE
Add button opening checklist page

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,8 +1,7 @@
 <script>
-
-	import { base } from "$app/paths";
-
+	import { base } from '$app/paths';
 </script>
+
 <footer class="footer footer-center p-10 bg-base-200 text-base-content rounded">
 	<div class="grid grid-flow-col gap-6">
 		<a
@@ -31,6 +30,6 @@
 		>
 	</div>
 	<div>
-		<p>© 2023 NMIND.</p>
+		<p>© 2024 NMIND.</p>
 	</div>
 </footer>

--- a/src/lib/components/PaginatedTools.svelte
+++ b/src/lib/components/PaginatedTools.svelte
@@ -71,6 +71,18 @@
 <div
 	class="flex grow flex-wrap flex-col items-center md:flex-row md:items-stretch md:justify-around lg:justify-center mb-4 lg:gap-8 xl:gap-12"
 >
+	<div id="checklistButton">
+		<label for="checklist" class="label">
+			<span class="label-text text-lg">Checklist:</span>
+		</label>
+		<button
+			type="button"
+			class="btn btn-primary btn-md"
+			style="color: #fff;"
+			on:click={() => window.open('https://www.nmind.org/standards-checklist/', '_blank')}
+			id="checklist">Add a tool
+		</button>
+	</div>
 	<div id="textSearch">
 		<label for="tool-name" class="label">
 			<span class="label-text text-lg">Search by text:</span>
@@ -161,7 +173,7 @@
 				</label>
 			</div>
 		</div>
-	</div>
+	</div>		
 </div>
 
 <hr class="mt-12" />


### PR DESCRIPTION
This PR is part of a bigger group of PRs across the proceedings and checklist repos to add functionality for simplifying / streamlining the checklist submission process.

The location of the checklist page is not easily accessible at the moment. This adds a button by the filtering bar in a contrasting colour, which opens the checklist in a new window, allowing for users to go through the checklist if they wish to add a tool.

![image](https://github.com/user-attachments/assets/794b1a78-d9cd-4865-b906-09f16c6baec3)

Also updated the footer year.