### PR TITLE
Add actions workflow for checklist submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/checklist.yaml
@@ -1,0 +1,25 @@
+name: Checklist Submission
+description: Submit a new checklist for a tool
+title: "Checklist: "
+labels: ["checklist"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for submitting a new checklist!
+  
+  - type: textarea
+    id: checklist
+    attributes:
+      label: Checklist content
+      description: Provide the JSON checklist content
+      placeholder: 'ex. {"name": "tool name"}'
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Additional information
+      description: Please provide us with any additional information
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/checklist.yaml
+++ b/.github/ISSUE_TEMPLATE/checklist.yaml
@@ -5,7 +5,11 @@ labels: ["checklist"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for submitting a new checklist!
+      value: |
+        Thanks for choosing to submit a new checklist! 
+        
+        Please take a quick look at the 
+        [submission workflow](https://github.com/nmind/proceedings?tab=readme-ov-file#workflow).
   
   - type: textarea
     id: checklist
@@ -23,3 +27,12 @@ body:
       description: Please provide us with any additional information
     validations:
       required: false
+
+  - type: checkboxes
+    id: agreement
+    attributes:
+      label: Agreement
+      description: By submitting this checklist, you understand and agree to the submission process.
+      options:
+        - label: I agree
+          required: true

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -1,0 +1,16 @@
+name: Other
+description: Report a bug / suggest a feature to help us improve
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting a bug / suggesting a new feature
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug / feature
+      description: Describe the bug / feature and the expected behaviour
+      placeholder: |
+        A clear, concise description of the bug / feature and the expected behaviour
+    validations:
+      required: true

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -1,0 +1,65 @@
+name: Add checklist
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  update-proceedings:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check labels
+        id: check_labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(label => label.name);
+            const hasApproved = labels.includes('approved');
+            const hasChecklist = labels.includes('checklist');
+            return hasApproved && hasChecklist;
+      
+      - name: Early exit
+        if: steps.check_labels.outputs.result == 'false'
+        run: echo "Not an approved checklist issue - exiting"
+
+      - name: Checkout
+        if: steps.check_labels.outputs.result == 'true'
+        uses: actions/checkout@v4
+
+      - name: Extract checklist data
+        if: steps.check_labels.outputs.result == 'true'
+        run: |
+          issue_body='${{ github.event.issue.body }}'
+          checklist=$(echo "$issue_body" | sed -n '/```json/,/```/p' | sed '1d;$d')
+          name=$(echo "$checklist" | jq -r '.name' | sed 's/ /_/g')
+          echo "checklist=$(echo $checklist)" >> $GITHUB_ENV
+          echo "name=$(echo $name)" >> $GITHUB_ENV
+
+      - name: Create file
+        if: steps.check_labels.outputs.result == 'true'
+        run: |
+          file_name="src/lib/data/entries/checklist_${{ env.name }}.json"
+          echo "file_name=$(echo $file_name)" >> $GITHUB_ENV
+          echo '${{ env.checklist }}' | jq . > $file_name
+
+      - name: Validate checklist
+        if: steps.check_labels.outputs.result == 'true'
+        uses: GrantBirki/json-yaml-validate@v3
+        with:
+          base_dir: src/lib/data/entries
+          json_schema: src/lib/data/evaluationSchemas/checklist_schema.json
+          ajv_strict_mode: false
+          json_exclude_regex: ''
+      
+      - name: Configure git
+        if: steps.check_labels.outputs.result == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+        
+      - name: Push to proceedings page
+        if: steps.check_labels.outputs.result == 'true'
+        run: |
+          git add ${{ env.file_name }}
+          git commit -m 'Closes #${{ github.event.issue.number }}'
+          git push

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ pflannery.vscode-versionlens
 svelte.svelte-vscode
 ```
 
+## Workflow
+
+The workflow to add a new tool to the proceedings page is as follows:
+
+```mermaid
+flowchart LR
+  A(User checklist submission) --> B(Github Issue)
+  B --> C(Checklist review)
+  C --> D{Approved?}
+  D -->|No| E(Revision)
+  E --> C
+  D -->|Yes| F(Added to proceedings)
+```
+
+1. User submits checklist from the [web app](https://nmind.org/standards-checklist)
+2. An issue is created from submitted checklist
+3. Review process with NMIND moderator via created issue
+4. When approved (addition of `approved` label), user submission is added to the [checklist](https://nmind.org/proceedings) via CI.
+
 ## Developing
 
 Once you've pulled down the repo with e.g. `git clone` and installed dependencies with `npm install`, start a development server:

--- a/src/lib/data/evaluationSchemas/checklist_schema.json
+++ b/src/lib/data/evaluationSchemas/checklist_schema.json
@@ -1,0 +1,417 @@
+{
+  "title": "NMIND checklist",
+  "description": "Checklists for bronze, silver, and gold tiers of NMIND standards",
+  "type": "object",
+  "properties": {
+    "name": {
+      "title": "Software name",
+      "type": "string"
+    },
+    "urls": {
+      "title": "Links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "title": "Link",
+            "type": "string"
+          },
+          "url_type": {
+            "title": "Link type",
+            "type": "string",
+            "enum": [
+              "Landing page",
+              "Source code",
+              "Documentation"
+            ],
+            "default": "Landing page"
+          }
+        },
+        "required": [
+          "url",
+          "url_type"
+        ],
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "documentation": {
+      "type": "object",
+      "properties": {
+        "bronze": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Landing page (e.g., GitHub README, website) provides a link to documentation and brief description of what program does",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Documentation is up to date with version of software",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Typical intended usage is described",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "An example of its usage is shown",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Document functions intended to be used by users",
+              "description": "(i.e., public function docstring / help coverage ≥ 10%)",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "Description of required input parameters for user-facing functions with reasonable description of inputs",
+              "description": "(i.e., \"NIfTI of brain mask in MNI\" vs. \"An image file\")",
+              "default": false
+            },
+            "7": {
+              "type": "boolean",
+              "title": "Description of output(s)",
+              "default": false
+            },
+            "8": {
+              "type": "boolean",
+              "title": "User installation instructions available",
+              "default": false
+            },
+            "9": {
+              "type": "boolean",
+              "title": "Dependencies listed",
+              "description": "(i.e., external and within-language requirements)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9"
+          ],
+          "additionalProperties": false
+        },
+        "silver": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Background/significance of program",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "One or more tutorial to showcase the multiple of the program's usages",
+              "description": "(i.e., if program has multiple usages)",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Any alternative usage that is advertised is thoroughly documented",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "Thorough description of required and optional input parameters",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Document public functions",
+              "description": "(i.e., public function docstring / help coverage ≥ 20%)",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "A statement of supported operating systems / environments",
+              "description": "(i.e., could be a container recipe)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6"
+          ],
+          "additionalProperties": false
+        },
+        "gold": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Continuous integration badges in README for build status",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Continuous integration badges in README for tests passing",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Continuous integration badges in README for coverage",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "Document functions, classes, modules, etc.",
+              "description": "(i.e., public + private docstring / help coverage ≥ 40%)",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Has a documented style guide",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "Maintenance status is documented",
+              "description": "(e.g., expected turnaround time on pull requests, whether project is maintained)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "bronze",
+        "silver",
+        "gold"
+      ],
+      "additionalProperties": false
+    },
+    "infrastructure": {
+      "type": "object",
+      "properties": {
+        "bronze": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Code is open source",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Package is under version control",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Readme is present",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "License is present",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Issues tracking is enabled",
+              "description": "(i.e., either through GitHub or external site)",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "Digital Object Identifier (DOI) points to latest version",
+              "description": "(e.g., Zenodo)",
+              "default": false
+            },
+            "7": {
+              "type": "boolean",
+              "title": "All documented installation instructions can be successfully followed",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7"
+          ],
+          "additionalProperties": false
+        },
+        "silver": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Issue template(s) available",
+              "description": "(i.e., information requested by developers)",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Continuous integration runs tests",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "No excessive files included",
+              "description": "(i.e., unused files / cache; e.g., .gitignore)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3"
+          ],
+          "additionalProperties": false
+        },
+        "gold": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Continuous integration builds packages",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Continuous integration validates style",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Journal of Open Source Software submission",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "Contribution guide present",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Code of Conduct present",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "bronze",
+        "silver",
+        "gold"
+      ],
+      "additionalProperties": false
+    },
+    "testing": {
+      "type": "object",
+      "properties": {
+        "bronze": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Provide / generate / point to test data",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Provide instructions for users to run tests that include instructions for evaluation for correct behavior",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2"
+          ],
+          "additionalProperties": false
+        },
+        "silver": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Some form of testing suite present",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Test coverage > 50%",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2"
+          ],
+          "additionalProperties": false
+        },
+        "gold": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Test coverage > 90%",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Benchmarking information is provided for examples",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "bronze",
+        "silver",
+        "gold"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "name",
+    "urls",
+    "documentation",
+    "infrastructure",
+    "testing"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
This PR is part of a bigger group of PRs across the proceedings and checklist repos to add functionality for simplifying / streamlining the checklist submission process:

1. Added a couple of issue templates for (a) submission of a checklist (with `checklist` label) and (b) "other" issue template, intended for all other issues such as bugs, features, etc. The checklist template is also used to pre-fill checklist from the submissions page.

2. Added an actions CI, which triggers on the addition of the `approved` label (together with the `checklist` label) will:
    a. Extract the checklist data from the issue
    b. Create the necessary file and validate it against the schema (grabbed from the checklist repo)
    c. Push to the proceedings page before closing the issue if no errors