### PR TITLE
Add issues write permission for checklist action

### DIFF
--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
 
     steps:
       - name: Check labels


### PR DESCRIPTION
The `GITHUB_TOKEN` [default permissions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) were changed when `contents: write` was added to the workflow, leading to issue permission to be set to `none` (see [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token). This PR sets issue permissions to `write`, which will allow the workflow to automatically close issues upon approval again.

Closes #38 