### PR TITLE
Automate simple README badge

### DIFF
--- a/.github/scripts/create_badge.py
+++ b/.github/scripts/create_badge.py
@@ -21,7 +21,7 @@ def count_bools(obj: Any) -> tuple[int, int]:
             false_count += f
         return true_count, false_count
     else:
-        raise TypeError(f"Unsupported type: {type(obj)}")
+        return 0, 0  # Irrelevant type
 
 
 def generate_badge(true_count: int, false_count: int) -> str:
@@ -47,14 +47,7 @@ def generate_badge(true_count: int, false_count: int) -> str:
 def process_checklist(checklist_path: Path) -> str:
     """Process a checklist, generating a badge."""
     checklist = json.loads(checklist_path.read_text())
-
-    eval_meta = checklist.get("evaluations")
-    if not eval_meta:
-        raise ValueError("No evaluations found.")
-    evals = eval_meta[0].get("checklist")
-    if not checklist:
-        raise ValueError("No checklist items found.")
-    true_count, false_count = count_bools(evals)
+    true_count, false_count = count_bools(checklist)
     badge_url = generate_badge(true_count=true_count, false_count=false_count)
 
     return badge_url
@@ -65,4 +58,4 @@ if __name__ == "__main__":
         print("Usage: create_badge.py <path_to_checklist_json>")
         sys.exit(1)
     checklist_fp = Path(sys.argv[1])
-    process_checklist(checklist_fp)
+    print(process_checklist(checklist_fp))

--- a/.github/scripts/create_badge.py
+++ b/.github/scripts/create_badge.py
@@ -1,54 +1,131 @@
 #!/usr/bin/env python
 
+import base64
 import json
 import sys
+from enum import Enum
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote_plus
 
+CategoryCounts = dict[str, dict[str, tuple[int, int]]]
 
-def count_bools(obj: Any) -> tuple[int, int]:
-    """Count number of trues and falses in checklist."""
-    if obj is True:
-        return 1, 0
-    elif obj is False:
-        return 0, 1
-    elif isinstance(obj, dict):
-        true_count = false_count = 0
-        for v in obj.values():
-            t, f = count_bools(v)
-            true_count += t
-            false_count += f
-        return true_count, false_count
+
+class ComplianceColor(str, Enum):
+    GREY = "lightgrey"
+    RED = "red"
+    ORANGE = "orange"
+    YELLOW = "yellow"
+    GREEN = "green"
+
+
+class ShieldColor(str, Enum):
+    BRONZE = "#CD7F32"
+    SILVER = "#1C274C"
+    GOLD = "#FFD700"
+
+
+def count_category_tier_bools(obj: Any) -> CategoryCounts:
+    """Count number of trues and falses by tier and category."""
+    return {
+        category: {
+            tier: (
+                sum(
+                    val is True for val in obj.get(category, {}).get(tier, {}).values()
+                ),
+                sum(
+                    val is False for val in obj.get(category, {}).get(tier, {}).values()
+                ),
+            )
+            for tier in ("bronze", "silver", "gold")
+        }
+        for category in ("documentation", "infrastructure", "testing")
+    }
+
+
+def count_total_bools(counts: CategoryCounts) -> tuple[int, int]:
+    """Count total number of trues and falses."""
+    return (
+        sum(true_count for cat in counts.values() for true_count, _ in cat.values()),
+        sum(false_count for cat in counts.values() for _, false_count in cat.values()),
+    )
+
+
+def get_highest_tier(counts: CategoryCounts) -> str | None:
+    """Return highest completed tier."""
+    return next(
+        (
+            tier
+            for tier in ("gold", "silver", "bronze")
+            if any(
+                false_count == 0
+                for false_count in (counts[cat][tier][1] for cat in counts)
+            )
+        ),
+        None,
+    )
+
+
+def get_compliance_color(ratio: float) -> ComplianceColor:
+    """Return compliance color."""
+    if ratio <= 0.25:
+        return ComplianceColor.RED
+    elif ratio <= 0.5:
+        return ComplianceColor.ORANGE
+    elif ratio <= 0.75:
+        return ComplianceColor.YELLOW
     else:
-        return 0, 0  # Irrelevant type
+        return ComplianceColor.GREEN
 
 
-def generate_badge(true_count: int, false_count: int) -> str:
+def get_shield_color(tier: str) -> ShieldColor:
+    """Return shield color."""
+    if tier == "bronze":
+        return ShieldColor.BRONZE
+    elif tier == "silver":
+        return ShieldColor.SILVER
+    elif tier == "gold":
+        return ShieldColor.GOLD
+    else:
+        raise ValueError(f"Unknown tier provided: {tier}")
+
+
+def generate_shield(tier: str) -> ...:
+    """Generate base64 encoded svg shield"""
+    shield_color = get_shield_color(tier)
+    shield_xml = f"""<svg viewBox="0 0 24 24" fill="{shield_color}" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3.37752 5.08241C3 5.62028 3 7.21907 3 10.4167V11.9914C3 17.6294 7.23896 20.3655 9.89856 21.5273C10.62 21.8424 10.9807 22 12 22C13.0193 22 13.38 21.8424 14.1014 21.5273C16.761 20.3655 21 17.6294 21 11.9914V10.4167C21 7.21907 21 5.62028 20.6225 5.08241C20.245 4.54454 18.7417 4.02996 15.7351 3.00079L15.1623 2.80472C13.595 2.26824 12.8114 2 12 2C11.1886 2 10.405 2.26824 8.83772 2.80472L8.26491 3.00079C5.25832 4.02996 3.75503 4.54454 3.37752 5.08241Z"/>
+</svg>
+"""
+    return base64.b64encode(shield_xml.encode()).decode()
+
+
+def generate_badge(true_count: int, false_count: int, highest_tier: str | None) -> str:
     """Generate a shields.io badge based on checklist counts."""
     total = true_count + false_count
     if total == 0:
-        return f"https://img.shields.io/badge/NMIND-{quote_plus('0/0')}-lightgrey"
-    ratio = true_count / total
-    color = (
-        "red"
-        if ratio <= 0.25
-        else "orange"
-        if ratio <= 0.5
-        else "yellow"
-        if ratio <= 0.75
-        else "green"
-    )
+        return f"https://img.shields.io/badge/NMIND-{quote_plus('0/0')}-{ComplianceColor.GREY}"
 
+    compliance_color = get_compliance_color(true_count / total)
     msg = f"{true_count}/{total}"
-    return f"https://img.shields.io/badge/NMIND-{quote_plus(msg)}-{color}"
+    badge_content = f"NMIND-{quote_plus(msg)}-{compliance_color}"
+    if highest_tier:
+        badge_content += (
+            f"?logo=data:image/svg+xml;base64,{generate_shield(highest_tier)}"
+        )
+
+    return f"https://img.shields.io/badge/{badge_content}"
 
 
 def process_checklist(checklist_path: Path) -> str:
     """Process a checklist, generating a badge."""
     checklist = json.loads(checklist_path.read_text())
-    true_count, false_count = count_bools(checklist)
-    badge_url = generate_badge(true_count=true_count, false_count=false_count)
+    category_counts = count_category_tier_bools(obj=checklist)
+    true_count, false_count = count_total_bools(counts=category_counts)
+    highest_tier = get_highest_tier(counts=category_counts)
+    badge_url = generate_badge(
+        true_count=true_count, false_count=false_count, highest_tier=highest_tier
+    )
 
     return badge_url
 

--- a/.github/scripts/create_badge.py
+++ b/.github/scripts/create_badge.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote_plus
+
+
+def count_bools(obj: Any) -> tuple[int, int]:
+    """Count number of trues and falses in checklist."""
+    if obj is True:
+        return 1, 0
+    elif obj is False:
+        return 0, 1
+    elif isinstance(obj, dict):
+        true_count = false_count = 0
+        for v in obj.values():
+            t, f = count_bools(v)
+            true_count += t
+            false_count += f
+        return true_count, false_count
+    else:
+        raise TypeError(f"Unsupported type: {type(obj)}")
+
+
+def generate_badge(true_count: int, false_count: int) -> str:
+    """Generate a shields.io badge based on checklist counts."""
+    total = true_count + false_count
+    if total == 0:
+        return f"https://img.shields.io/badge/NMIND-{quote_plus('0/0')}-lightgrey"
+    ratio = true_count / total
+    color = (
+        "red"
+        if ratio <= 0.25
+        else "orange"
+        if ratio <= 0.5
+        else "yellow"
+        if ratio <= 0.75
+        else "green"
+    )
+
+    msg = f"{true_count}/{total}"
+    return f"https://img.shields.io/badge/NMIND-{quote_plus(msg)}-{color}"
+
+
+def process_checklist(checklist_path: Path) -> str:
+    """Process a checklist, generating a badge."""
+    checklist = json.loads(checklist_path.read_text())
+
+    eval_meta = checklist.get("evaluations")
+    if not eval_meta:
+        raise ValueError("No evaluations found.")
+    evals = eval_meta[0].get("checklist")
+    if not checklist:
+        raise ValueError("No checklist items found.")
+    true_count, false_count = count_bools(evals)
+    badge_url = generate_badge(true_count=true_count, false_count=false_count)
+
+    return badge_url
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: create_badge.py <path_to_checklist_json>")
+        sys.exit(1)
+    checklist_fp = Path(sys.argv[1])
+    process_checklist(checklist_fp)

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -52,7 +52,7 @@ jobs:
           base_dir: src/lib/data/entries
           json_schema: .github/static/checklist_schema.json
           ajv_strict_mode: false
-          json_exclude_regex: ''
+          files: ${{ env.file_name }}
       
       - name: Configure git
         if: steps.check_labels.outputs.result == 'true'
@@ -66,4 +66,3 @@ jobs:
           git add ${{ env.file_name }}
           git commit -m 'Closes #${{ github.event.issue.number }}'
           git push 
-          

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -86,7 +86,7 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            ✅ **Your NMIND badge has been generated!**: 
+            ✅ **Your new NMIND badge has been generated!**: 
             ![${{ env.name }}](${{ env.badge }})
 
             🔗 **Badge URL**:

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           issue_body='${{ github.event.issue.body }}'
           checklist=$(echo "$issue_body" | sed -n '/```json/I,/```/p' | sed '1d;$d')
-          name=$(echo "$checklist" | jq -r '.name' | sed 's/ /_/g')
+          name=$(echo "$checklist" | jq -r '.name' | sed -e 's/ /_/g' -e 's/-/_/g')
           echo "checklist=$(echo $checklist)" >> $GITHUB_ENV
           echo "name=$(echo $name)" >> $GITHUB_ENV
 
@@ -86,7 +86,8 @@ jobs:
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
-            ✅ **Your NMIND badge has been generated!**: ![${{ env.name }}](${{ env.badge }})
+            ✅ **Your NMIND badge has been generated!**: 
+            ![${{ env.name }}](${{ env.badge }})
 
             🔗 **Badge URL**:
             ```
@@ -95,6 +96,6 @@ jobs:
 
             📄 **To embed this badge in a `README.md`, use the following Markdown:**
             ```md
-            ![${{ env.name }}](${{ env.badge }})
+            [![${{ env.name }}](${{ env.badge }})](https://nmind.org/proceedings/${{ env.name }})
             ```
             

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -66,3 +66,35 @@ jobs:
           git add ${{ env.file_name }}
           git commit -m 'Closes #${{ github.event.issue.number }}'
           git push 
+
+      # Badge generation steps
+      - name: Setup Python
+        if: steps.check_labels.outputs.result == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+        
+      - name: Generate badge
+        if: steps.check_labels.outputs.result == 'true'
+        run: |
+          badge_url=$(python .github/scripts/create_badge.py "${{ env.file_name }}")
+          echo "badge=$(echo $badge_url)" >> $GITHUB_ENV
+      
+      - name: Comment on issue
+        if: steps.check_labels.outputs.result == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ✅ **Your NMIND badge has been generated!**: ![${{ env.name }}](${{ env.badge }})
+
+            🔗 **Badge URL**:
+            ```
+            ${{ env.badge }}
+            ```
+
+            📄 **To embed this badge in a `README.md`, use the following Markdown:**
+            ```md
+            ![${{ env.name }}](${{ env.badge }})
+            ```
+            


### PR DESCRIPTION
Partially addresses #2 (I wasn't quite of the format mentioned, but will ask and make changes if needed). This PR primarily adds to the existing checklist workflow with:

- Python script to count checklist items and return badge URL
- Reply to existing issue with badge, url, and markdown code to include in README (redirecting to the tool's NMIND checklist page). Example below:
![image](https://github.com/user-attachments/assets/f30916b2-8ec8-4509-b2cb-89e4a0dfb0f9)

The color of the badge is dependent on the color coding compliance proposed in #2.

Additionally, this PR makes the following changes to the workflow:
- Changes validation of repository checklists from all available to only the checklist approved
- Replaces dashes ('-') with underscores ('_')