### PR TITLE
Simplify / synchronize schema

### DIFF
--- a/.github/static/checklist_schema.json
+++ b/.github/static/checklist_schema.json
@@ -1,417 +1,454 @@
 {
-    "title": "NMIND checklist",
-    "description": "Checklists for bronze, silver, and gold tiers of NMIND standards",
-    "type": "object",
-    "properties": {
-      "name": {
-        "title": "Software name",
-        "type": "string"
-      },
-      "urls": {
-        "title": "Links",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "url": {
-              "title": "Link",
-              "type": "string"
-            },
-            "url_type": {
-              "title": "Link type",
-              "type": "string",
-              "enum": [
-                "Landing page",
-                "Source code",
-                "Documentation"
-              ],
-              "default": "Landing page"
-            }
-          },
-          "required": [
-            "url",
-            "url_type"
-          ],
-          "additionalProperties": false
-        },
-        "default": []
-      },
-      "documentation": {
+  "title": "NMIND checklist",
+  "description": "Checklists for bronze, silver, and gold tiers of NMIND standards",
+  "type": "object",
+  "properties": {
+    "checklist_version": {
+      "title": "Checklist version",
+      "type": "string"
+    },
+    "date": {
+      "title": "Checklist evaluation acceptance date",
+      "type": "string",
+      "format": "date"
+    },
+    "evaluators": {
+      "title": "Evaluators",
+      "type": "array",
+      "items": {
         "type": "object",
         "properties": {
-          "bronze": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Landing page (e.g., GitHub README, website) provides a link to documentation and brief description of what program does",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Documentation is up to date with version of software",
-                "default": false
-              },
-              "3": {
-                "type": "boolean",
-                "title": "Typical intended usage is described",
-                "default": false
-              },
-              "4": {
-                "type": "boolean",
-                "title": "An example of its usage is shown",
-                "default": false
-              },
-              "5": {
-                "type": "boolean",
-                "title": "Document functions intended to be used by users",
-                "description": "(i.e., public function docstring / help coverage ≥ 10%)",
-                "default": false
-              },
-              "6": {
-                "type": "boolean",
-                "title": "Description of required input parameters for user-facing functions with reasonable description of inputs",
-                "description": "(i.e., \"NIfTI of brain mask in MNI\" vs. \"An image file\")",
-                "default": false
-              },
-              "7": {
-                "type": "boolean",
-                "title": "Description of output(s)",
-                "default": false
-              },
-              "8": {
-                "type": "boolean",
-                "title": "User installation instructions available",
-                "default": false
-              },
-              "9": {
-                "type": "boolean",
-                "title": "Dependencies listed",
-                "description": "(i.e., external and within-language requirements)",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5",
-              "6",
-              "7",
-              "8",
-              "9"
-            ],
-            "additionalProperties": false
+          "name": {
+            "title": "Evaluator",
+            "type": "string"
           },
-          "silver": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Background/significance of program",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "One or more tutorial to showcase the multiple of the program's usages",
-                "description": "(i.e., if program has multiple usages)",
-                "default": false
-              },
-              "3": {
-                "type": "boolean",
-                "title": "Any alternative usage that is advertised is thoroughly documented",
-                "default": false
-              },
-              "4": {
-                "type": "boolean",
-                "title": "Thorough description of required and optional input parameters",
-                "default": false
-              },
-              "5": {
-                "type": "boolean",
-                "title": "Document public functions",
-                "description": "(i.e., public function docstring / help coverage ≥ 20%)",
-                "default": false
-              },
-              "6": {
-                "type": "boolean",
-                "title": "A statement of supported operating systems / environments",
-                "description": "(i.e., could be a container recipe)",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5",
-              "6"
-            ],
-            "additionalProperties": false
-          },
-          "gold": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Continuous integration badges in README for build status",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Continuous integration badges in README for tests passing",
-                "default": false
-              },
-              "3": {
-                "type": "boolean",
-                "title": "Continuous integration badges in README for coverage",
-                "default": false
-              },
-              "4": {
-                "type": "boolean",
-                "title": "Document functions, classes, modules, etc.",
-                "description": "(i.e., public + private docstring / help coverage ≥ 40%)",
-                "default": false
-              },
-              "5": {
-                "type": "boolean",
-                "title": "Has a documented style guide",
-                "default": false
-              },
-              "6": {
-                "type": "boolean",
-                "title": "Maintenance status is documented",
-                "description": "(e.g., expected turnaround time on pull requests, whether project is maintained)",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5",
-              "6"
-            ],
-            "additionalProperties": false
+          "contact": {
+            "title": "Github contact",
+            "type": "string"
           }
         },
-        "required": [
-          "bronze",
-          "silver",
-          "gold"
-        ],
-        "additionalProperties": false
-      },
-      "infrastructure": {
-        "type": "object",
-        "properties": {
-          "bronze": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Code is open source",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Package is under version control",
-                "default": false
-              },
-              "3": {
-                "type": "boolean",
-                "title": "Readme is present",
-                "default": false
-              },
-              "4": {
-                "type": "boolean",
-                "title": "License is present",
-                "default": false
-              },
-              "5": {
-                "type": "boolean",
-                "title": "Issues tracking is enabled",
-                "description": "(i.e., either through GitHub or external site)",
-                "default": false
-              },
-              "6": {
-                "type": "boolean",
-                "title": "Digital Object Identifier (DOI) points to latest version",
-                "description": "(e.g., Zenodo)",
-                "default": false
-              },
-              "7": {
-                "type": "boolean",
-                "title": "All documented installation instructions can be successfully followed",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5",
-              "6",
-              "7"
-            ],
-            "additionalProperties": false
-          },
-          "silver": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Issue template(s) available",
-                "description": "(i.e., information requested by developers)",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Continuous integration runs tests",
-                "default": false
-              },
-              "3": {
-                "type": "boolean",
-                "title": "No excessive files included",
-                "description": "(i.e., unused files / cache; e.g., .gitignore)",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2",
-              "3"
-            ],
-            "additionalProperties": false
-          },
-          "gold": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Continuous integration builds packages",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Continuous integration validates style",
-                "default": false
-              },
-              "3": {
-                "type": "boolean",
-                "title": "Journal of Open Source Software submission",
-                "default": false
-              },
-              "4": {
-                "type": "boolean",
-                "title": "Contribution guide present",
-                "default": false
-              },
-              "5": {
-                "type": "boolean",
-                "title": "Code of Conduct present",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2",
-              "3",
-              "4",
-              "5"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "required": [
-          "bronze",
-          "silver",
-          "gold"
-        ],
-        "additionalProperties": false
-      },
-      "testing": {
-        "type": "object",
-        "properties": {
-          "bronze": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Provide / generate / point to test data",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Provide instructions for users to run tests that include instructions for evaluation for correct behavior",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2"
-            ],
-            "additionalProperties": false
-          },
-          "silver": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Some form of testing suite present",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Test coverage > 50%",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2"
-            ],
-            "additionalProperties": false
-          },
-          "gold": {
-            "type": "object",
-            "properties": {
-              "1": {
-                "type": "boolean",
-                "title": "Test coverage > 90%",
-                "default": false
-              },
-              "2": {
-                "type": "boolean",
-                "title": "Benchmarking information is provided for examples",
-                "default": false
-              }
-            },
-            "required": [
-              "1",
-              "2"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "required": [
-          "bronze",
-          "silver",
-          "gold"
-        ],
         "additionalProperties": false
       }
     },
-    "required": [
-      "name",
-      "urls",
-      "documentation",
-      "infrastructure",
-      "testing"
-    ],
-    "additionalProperties": false
-  }
+    "history": {
+      "title": "Checklist evaluation history",
+      "description": "Link to github commit history to see changes between evaluations",
+      "type": "string",
+      "format": "uri"
+    },
+    "name": {
+      "title": "Software name",
+      "type": "string"
+    },
+    "image": {
+      "title": "Software logo",
+      "type": "string"
+    },
+    "urls": {
+      "title": "Links",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "title": "Link",
+            "type": "string"
+          },
+          "url_type": {
+            "title": "Link type",
+            "type": "string",
+            "enum": [
+              "Landing page",
+              "Source code",
+              "Documentation"
+            ],
+            "default": "Landing page"
+          }
+        },
+        "required": [
+          "url",
+          "url_type"
+        ],
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "documentation": {
+      "type": "object",
+      "properties": {
+        "bronze": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Landing page (e.g., GitHub README, website) provides a link to documentation and brief description of what program does",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Documentation is up to date with version of software",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Typical intended usage is described",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "An example of its usage is shown",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Document functions intended to be used by users",
+              "description": "(i.e., public function docstring / help coverage ≥ 10%)",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "Description of required input parameters for user-facing functions with reasonable description of inputs",
+              "description": "(i.e., \"NIfTI of brain mask in MNI\" vs. \"An image file\")",
+              "default": false
+            },
+            "7": {
+              "type": "boolean",
+              "title": "Description of output(s)",
+              "default": false
+            },
+            "8": {
+              "type": "boolean",
+              "title": "User installation instructions available",
+              "default": false
+            },
+            "9": {
+              "type": "boolean",
+              "title": "Dependencies listed",
+              "description": "(i.e., external and within-language requirements)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9"
+          ],
+          "additionalProperties": false
+        },
+        "silver": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Background/significance of program",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "One or more tutorial to showcase the multiple of the program's usages",
+              "description": "(i.e., if program has multiple usages)",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Any alternative usage that is advertised is thoroughly documented",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "Thorough description of required and optional input parameters",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Document public functions",
+              "description": "(i.e., public function docstring / help coverage ≥ 20%)",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "A statement of supported operating systems / environments",
+              "description": "(i.e., could be a container recipe)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6"
+          ],
+          "additionalProperties": false
+        },
+        "gold": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Continuous integration badges in README for build status",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Continuous integration badges in README for tests passing",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Continuous integration badges in README for coverage",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "Document functions, classes, modules, etc.",
+              "description": "(i.e., public + private docstring / help coverage ≥ 40%)",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Has a documented style guide",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "Maintenance status is documented",
+              "description": "(e.g., expected turnaround time on pull requests, whether project is maintained)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "bronze",
+        "silver",
+        "gold"
+      ],
+      "additionalProperties": false
+    },
+    "infrastructure": {
+      "type": "object",
+      "properties": {
+        "bronze": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Code is open source",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Package is under version control",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Readme is present",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "License is present",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Issues tracking is enabled",
+              "description": "(i.e., either through GitHub or external site)",
+              "default": false
+            },
+            "6": {
+              "type": "boolean",
+              "title": "Digital Object Identifier (DOI) points to latest version",
+              "description": "(e.g., Zenodo)",
+              "default": false
+            },
+            "7": {
+              "type": "boolean",
+              "title": "All documented installation instructions can be successfully followed",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7"
+          ],
+          "additionalProperties": false
+        },
+        "silver": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Issue template(s) available",
+              "description": "(i.e., information requested by developers)",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Continuous integration runs tests",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "No excessive files included",
+              "description": "(i.e., unused files / cache; e.g., .gitignore)",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3"
+          ],
+          "additionalProperties": false
+        },
+        "gold": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Continuous integration builds packages",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Continuous integration validates style",
+              "default": false
+            },
+            "3": {
+              "type": "boolean",
+              "title": "Journal of Open Source Software submission",
+              "default": false
+            },
+            "4": {
+              "type": "boolean",
+              "title": "Contribution guide present",
+              "default": false
+            },
+            "5": {
+              "type": "boolean",
+              "title": "Code of Conduct present",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "bronze",
+        "silver",
+        "gold"
+      ],
+      "additionalProperties": false
+    },
+    "testing": {
+      "type": "object",
+      "properties": {
+        "bronze": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Provide / generate / point to test data",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Provide instructions for users to run tests that include instructions for evaluation for correct behavior",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2"
+          ],
+          "additionalProperties": false
+        },
+        "silver": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Some form of testing suite present",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Test coverage > 50%",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2"
+          ],
+          "additionalProperties": false
+        },
+        "gold": {
+          "type": "object",
+          "properties": {
+            "1": {
+              "type": "boolean",
+              "title": "Test coverage > 90%",
+              "default": false
+            },
+            "2": {
+              "type": "boolean",
+              "title": "Benchmarking information is provided for examples",
+              "default": false
+            }
+          },
+          "required": [
+            "1",
+            "2"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "bronze",
+        "silver",
+        "gold"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "name",
+    "urls",
+    "documentation",
+    "infrastructure",
+    "testing"
+  ],
+  "additionalProperties": false
+}

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -9,6 +9,8 @@ jobs:
     permissions:
       contents: write
       issues: write
+    env:
+      checklist_version: "1.1"
 
     steps:
       - name: Check labels
@@ -32,10 +34,30 @@ jobs:
       - name: Extract checklist data
         if: steps.check_labels.outputs.result == 'true'
         run: |
+          # Extract checklist
           issue_body='${{ github.event.issue.body }}'
-          checklist=$(echo "$issue_body" | sed -n '/```json/I,/```/p' | sed '1d;$d')
-          name=$(echo "$checklist" | jq -r '.name' | sed -e 's/ /_/g' -e 's/-/_/g')
-          echo "checklist=$(echo $checklist)" >> $GITHUB_ENV
+          checklist_json=$(echo "$issue_body" | sed -n '/```json/I,/```/p' | sed '1d;$d')
+          name=$(echo "$checklist_json" | jq -r '.name' | sed -e 's/ /_/g' -e 's/-/_/g')
+
+          # Add date, evaluators, history
+          date_str=$(date +%F)
+          issue_json='${{ toJson(github.event.issue) }}'
+          evaluators=$(jq -r '[.assignees[] | {name: .login, contact: .html_url}]' <<< "$issue_json")
+          history="https://github.com/nmind/proceedings/commits/development/src/lib/data/entries/checklist_${name}.json"
+          image="brain_9_svgrepo_com--CadetBlue.png"
+
+          # Add additional checklist items
+          checklist_json=$(echo "$checklist_json" | jq \
+            --arg checklist_version "$checklist_version" \
+            --arg date "$date_str" \
+            --argjson evaluators "$evaluators" \
+            --arg history "$history" \
+            --arg image "$image" \
+            '. + {checklist_version: $checklist_version, date: $date, evaluators: $evaluators, history: $history, image: $image}')
+          echo $checklist_json
+
+          # Export variables to environment
+          echo "checklist=$(echo $checklist_json)" >> $GITHUB_ENV
           echo "name=$(echo $name)" >> $GITHUB_ENV
 
       - name: Create file


### PR DESCRIPTION
The first of a few PRs related to the schema and proceedings interface. The main change to this PR is to the checklist schema that is specific to this proceedings page (see https://github.com/nmind/proceedings/discussions/46). Briefly, there is a discrepancy between the schema used here and in the [standards-checklist page](https://github.com/nmind/standards-checklist). As a result, a migration script was previously created to ingest and transform submitted checklists to fit the schema here. This largely affected the tools that were originally added (e.g. [dcm2niix](https://github.com/nmind/proceedings/blob/development/src/lib/data/entries/checklist_dcm2niix.json)).

This PR will bring the schema used to be more closely aligned with that in the [standards-checklist repository](https://github.com/nmind/standards-checklist), while adding a few key properties that are available, but currently unused in the application - these properties would be autocompleted via the updated workflow. 

_Note, this PR is not intended to be merged in as is. A separate a PR will be made to introduce changes that allow for this schema to be compatible with the proceedings interface, but wanted to be able to show the file diff and incorporate any feedback here for the downstream changes._
