### PR TITLE
Fix readme badge color and url

### DIFF
--- a/.github/scripts/create_badge.py
+++ b/.github/scripts/create_badge.py
@@ -93,7 +93,7 @@ def get_shield_color(tier: str) -> ShieldColor:
 def generate_shield(tier: str) -> ...:
     """Generate base64 encoded svg shield"""
     shield_color = get_shield_color(tier)
-    shield_xml = f"""<svg viewBox="0 0 24 24" fill="{shield_color}" xmlns="http://www.w3.org/2000/svg">
+    shield_xml = f"""<svg viewBox="0 0 24 24" fill="{shield_color.value}" xmlns="http://www.w3.org/2000/svg">
   <path d="M3.37752 5.08241C3 5.62028 3 7.21907 3 10.4167V11.9914C3 17.6294 7.23896 20.3655 9.89856 21.5273C10.62 21.8424 10.9807 22 12 22C13.0193 22 13.38 21.8424 14.1014 21.5273C16.761 20.3655 21 17.6294 21 11.9914V10.4167C21 7.21907 21 5.62028 20.6225 5.08241C20.245 4.54454 18.7417 4.02996 15.7351 3.00079L15.1623 2.80472C13.595 2.26824 12.8114 2 12 2C11.1886 2 10.405 2.26824 8.83772 2.80472L8.26491 3.00079C5.25832 4.02996 3.75503 4.54454 3.37752 5.08241Z"/>
 </svg>
 """
@@ -108,7 +108,7 @@ def generate_badge(true_count: int, false_count: int, highest_tier: str | None) 
 
     compliance_color = get_compliance_color(true_count / total)
     msg = f"{true_count}/{total}"
-    badge_content = f"NMIND-{quote_plus(msg)}-{compliance_color}"
+    badge_content = f"NMIND-{quote_plus(msg)}-{compliance_color.value}"
     if highest_tier:
         badge_content += (
             f"?logo=data:image/svg+xml;base64,{generate_shield(highest_tier)}"

--- a/.github/scripts/create_badge.py
+++ b/.github/scripts/create_badge.py
@@ -21,7 +21,7 @@ class ComplianceColor(str, Enum):
 
 class ShieldColor(str, Enum):
     BRONZE = "#CD7F32"
-    SILVER = "#1C274C"
+    SILVER = "#C5C5C5"
     GOLD = "#FFD700"
 
 

--- a/.github/workflows/checklist.yaml
+++ b/.github/workflows/checklist.yaml
@@ -20,7 +20,7 @@ jobs:
             const hasApproved = labels.includes('approved');
             const hasChecklist = labels.includes('checklist');
             return hasApproved && hasChecklist;
-      
+
       - name: Early exit
         if: steps.check_labels.outputs.result == 'false'
         run: echo "Not an approved checklist issue - exiting"
@@ -59,7 +59,7 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-        
+
       - name: Commit files
         if: steps.check_labels.outputs.result == 'true'
         run: |
@@ -79,6 +79,17 @@ jobs:
         run: |
           badge_url=$(python .github/scripts/create_badge.py "${{ env.file_name }}")
           echo "badge=$(echo $badge_url)" >> $GITHUB_ENV
+
+      # Generate url-safe, directly from checklist (env.name already altered)
+      - name: Generate URL-safe tool string
+        if: steps.check_labels.outputs.result == 'true'
+        run: |
+          tool_url=$(echo "$checklist" \
+            | jq -r '.name' \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9_ ]//g' \
+            | tr ' ' '-')
+          echo "safe_url=$(echo $tool_url)" >> $GITHUB_ENV
       
       - name: Comment on issue
         if: steps.check_labels.outputs.result == 'true'
@@ -96,6 +107,6 @@ jobs:
 
             📄 **To embed this badge in a `README.md`, use the following Markdown:**
             ```md
-            [![${{ env.name }}](${{ env.badge }})](https://nmind.org/proceedings/${{ env.name }})
+            [![${{ env.name }}](${{ env.badge }})](https://nmind.org/proceedings/${{ env.safe_url }})
             ```
             


### PR DESCRIPTION
Closes #50 - this PR fixes a few issues that were noticed recently.

1. Fixes python script to properly return the `enum` color values for the badge url.
2. Fixes the github actions workflow to properly generate a url-safe tool name (following same pattern as what is called by the `back_migrate.js` script). Here, the name is extracted again from the JSON in the issue rather instead from the name already altered within the workflow.

Here are a few test issues that had been opened to test the updated workflow for url correctness:
* https://github.com/kaitj/nmind-proceedings/issues/29 - spaces should be replaced by a dash (`-`)
* https://github.com/kaitj/nmind-proceedings/issues/33 - existing underscores (`_`) are retained
* https://github.com/kaitj/nmind-proceedings/issues/34 - existing dashes are removed

There might be a few edge cases that are missed, but these were ones I could find.